### PR TITLE
allow choosing the sha512 impl through digest::Digest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bip32-ed25519"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Shift Crypto AG <support@shiftcrypto.ch>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -9,12 +9,13 @@ categories = ["cryptography", "no-std"]
 description = "BIP32-Ed25519"
 
 [dependencies]
-sha2 = { version = "0.10", default-features = false }
+digest = { version = "0.10", default-features = false }
 hmac = { version = "0.12", default-features = false, features = ["reset"] }
 curve25519-dalek = { version = "4", default-features = false }
 zeroize = { version = "1", features = ["zeroize_derive"] }
 
 [dev-dependencies]
+sha2 = { version = "0.10", default-features = false }
 quickcheck = "1"
 quickcheck_macros = "1"
 num-bigint = "0.4.0"

--- a/tests/table_test.rs
+++ b/tests/table_test.rs
@@ -65,7 +65,7 @@ fn table_test() {
         k[..32].copy_from_slice(&test.kl);
         k[32..].copy_from_slice(&test.kr);
         for derivation in test.private_derivations.iter() {
-            let mut xprv = Xprv::from_normalize(&k, &test.chain_code);
+            let mut xprv = Xprv::<sha2::Sha512>::from_normalize(&k, &test.chain_code);
             let mut xprv_other = mk_other_xprv(&k, &test.chain_code);
             for index in derivation.path.iter() {
                 xprv = xprv.derive(*index);
@@ -99,7 +99,7 @@ fn table_test() {
             );
         }
         for derivation in test.public_derivations.iter() {
-            let mut xpub = Xprv::from_normalize(&k, &test.chain_code).public();
+            let mut xpub = Xprv::<sha2::Sha512>::from_normalize(&k, &test.chain_code).public();
             let mut xpub_other = mk_other_xprv(&k, &test.chain_code).public();
             for index in derivation.path.iter() {
                 xpub = xpub.derive(*index).unwrap();


### PR DESCRIPTION
This allows downstream users to choose their own
implementation. Useful for e.g. the BitBox02 to not pull in a second sha512 implementation next to another already existing one, to reduce binary bloat.