### PR TITLE
add ZeroizeOnDrop to XprvData and XPrv

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ use core::convert::TryInto;
 use core::ops::{Deref, DerefMut};
 use digest::{core_api::BlockSizeUser, typenum::U64, Digest};
 use hmac::{Mac, SimpleHmac};
-use zeroize::{Zeroize, Zeroizing};
+use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
 use curve25519_dalek::{
     edwards::{CompressedEdwardsY, EdwardsPoint},
@@ -115,8 +115,7 @@ impl<D: Digest<OutputSize = U64> + BlockSizeUser> Xpub<D> {
     }
 }
 
-#[derive(Zeroize, Clone, Debug, PartialEq)]
-#[zeroize(drop)]
+#[derive(Zeroize, ZeroizeOnDrop, Clone, Debug, PartialEq)]
 struct XprvData {
     // An xprv consists of an expanded Ed25519 secret key and a chain
     // code.
@@ -134,7 +133,7 @@ struct XprvData {
 }
 
 /// The `D` digest type param must implement SHA512. Use `sha2::Sha512` if in doubt.
-#[derive(Clone, Debug)]
+#[derive(Zeroize, ZeroizeOnDrop, Clone, Debug)]
 pub struct Xprv<D: Digest<OutputSize = U64> + BlockSizeUser + Clone>(
     // The data is boxed so that moving an `Xprv` does not accidentally
     // leave copies of the data on the stack.


### PR DESCRIPTION
This is a small MR changing how `Zeroize` is being used. The main contribution is adding `Zeroize` and `ZeroizeOnDrop` to `Xprv`.

A secondary change is removing `#[zeroize(drop)]` from `XprvData` and replacing it with `ZeroizeOnDrop` because it is deprecated according to [the documentation](https://docs.rs/zeroize/latest/zeroize/#custom-derive-support).

If I missed anything I am happy to edit the PR.